### PR TITLE
Add support for variadic arguments on provider constructor

### DIFF
--- a/test/variadic/v1.go
+++ b/test/variadic/v1.go
@@ -1,0 +1,15 @@
+package variadic
+
+type V1 struct {}
+
+func NewV1() V1 {
+	return V1{}
+}
+
+func (v1 V1) Something() bool {
+	return true
+}
+
+func (v1 V1) String() string {
+	return "v1"
+}

--- a/test/variadic/v2.go
+++ b/test/variadic/v2.go
@@ -1,0 +1,15 @@
+package variadic
+
+type V2 struct {}
+
+func NewV2() V2 {
+	return V2{}
+}
+
+func (v2 V2) Something() bool {
+	return true
+}
+
+func (v2 V2) String() string {
+	return "v2"
+}

--- a/test/variadic/v3.go
+++ b/test/variadic/v3.go
@@ -1,0 +1,15 @@
+package variadic
+
+type V3 struct {}
+
+func NewV3() V3 {
+	return V3{}
+}
+
+func (v3 V3) Something() bool {
+	return true
+}
+
+func (v3 V3) String() string {
+	return "v3"
+}

--- a/test/variadic/variadic.go
+++ b/test/variadic/variadic.go
@@ -1,0 +1,26 @@
+package variadic
+
+import "fmt"
+
+type Variadic interface {
+	Something() bool
+	fmt.Stringer
+}
+
+type VariadicContainer struct {
+	list []Variadic
+}
+
+func NewVariadicContainer(list ...Variadic) *VariadicContainer {
+	return &VariadicContainer{list: list}
+}
+
+func (vc VariadicContainer) GetInstalled() string {
+	var installed string
+
+	for _, item := range vc.list {
+		installed = fmt.Sprintf("%s,%s", installed, item.String())
+	}
+
+	return installed
+}

--- a/test/variadic_test.go
+++ b/test/variadic_test.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/karlkfi/inject"
+	"github.com/mumia/inject/test/variadic"
+	. "github.com/onsi/gomega"
+)
+
+func TestVariadicNone(t *testing.T) {
+	RegisterTestingT(t)
+
+	graph := inject.NewGraph()
+
+	var container *variadic.VariadicContainer
+
+	graph.Define(
+		&container,
+		inject.NewProvider(
+			func() *variadic.VariadicContainer{
+				return variadic.NewVariadicContainer()
+			},
+		),
+	)
+	graph.ResolveAll()
+
+	Expect(container.GetInstalled()).To(Equal(""))
+}
+
+func TestVariadicOne(t *testing.T) {
+	RegisterTestingT(t)
+
+	graph := inject.NewGraph()
+
+	var container *variadic.VariadicContainer
+
+	graph.Define(
+		&container,
+		inject.NewProvider(
+			func() *variadic.VariadicContainer{
+				return variadic.NewVariadicContainer(variadic.NewV1())
+			},
+		),
+	)
+	graph.ResolveAll()
+
+	Expect(container.GetInstalled()).To(Equal(",v1"))
+}
+
+func TestVariadicAll(t *testing.T) {
+	RegisterTestingT(t)
+
+	graph := inject.NewGraph()
+
+	var container *variadic.VariadicContainer
+
+	graph.Define(
+		&container,
+		inject.NewProvider(
+			func() *variadic.VariadicContainer{
+				return variadic.NewVariadicContainer(
+					variadic.NewV1(),
+					variadic.NewV2(),
+					variadic.NewV3(),
+				)
+			},
+		),
+	)
+	graph.ResolveAll()
+
+	Expect(container.GetInstalled()).To(Equal(",v1,v2,v3"))
+}

--- a/test/variadic_test.go
+++ b/test/variadic_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/karlkfi/inject"
-	"github.com/mumia/inject/test/variadic"
+	"github.com/karlkfi/inject/test/variadic"
 	. "github.com/onsi/gomega"
 )
 


### PR DESCRIPTION
Example:

```
dependencies.graph.Define(
        &dependencies.RouteRegistry,
        inject.NewProvider(
            routes.NewRouteRegistry,
            &dependencies.AuthenticationRoutes,
            &dependencies.AccountRoutes,
            &dependencies.BankRoutes,
            &dependencies.BaseRoutes,
        ),
    )
```
Where routes.NewRouteRegistry is:
```
func NewRouteRegistry(routes ...Route) RouteRegistry
```