### PR TITLE
Fix provider for slice arguments. fix #8

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -67,14 +67,10 @@ func (p provider) Provide(g Graph) reflect.Value {
 		arg := g.Resolve(p.argPtrs[i])
 		argType := arg.Type()
 
-		if i < fnType.NumIn() {
-			inType = fnType.In(i)
+		if fnType.IsVariadic() && i >= fnType.NumIn()-1 {
+			inType = fnType.In(fnType.NumIn() - 1).Elem()
 		} else {
-			inType = fnType.In(fnType.NumIn() - 1)
-		}
-
-		if inType.Kind() == reflect.Slice {
-			inType = inType.Elem()
+			inType = fnType.In(i)
 		}
 
 		if !argType.AssignableTo(inType) {

--- a/test/variadic/v1.go
+++ b/test/variadic/v1.go
@@ -1,9 +1,9 @@
 package variadic
 
-type V1 struct {}
+type V1 struct{}
 
-func NewV1() V1 {
-	return V1{}
+func NewV1() *V1 {
+	return &V1{}
 }
 
 func (v1 V1) Something() bool {

--- a/test/variadic/v2.go
+++ b/test/variadic/v2.go
@@ -1,9 +1,9 @@
 package variadic
 
-type V2 struct {}
+type V2 struct{}
 
-func NewV2() V2 {
-	return V2{}
+func NewV2() *V2 {
+	return &V2{}
 }
 
 func (v2 V2) Something() bool {

--- a/test/variadic/v3.go
+++ b/test/variadic/v3.go
@@ -1,9 +1,9 @@
 package variadic
 
-type V3 struct {}
+type V3 struct{}
 
-func NewV3() V3 {
-	return V3{}
+func NewV3() *V3 {
+	return &V3{}
 }
 
 func (v3 V3) Something() bool {

--- a/test/variadic/variadic.go
+++ b/test/variadic/variadic.go
@@ -2,20 +2,38 @@ package variadic
 
 import "fmt"
 
-type Variadic interface {
+type Item interface {
 	Something() bool
 	fmt.Stringer
 }
 
 type VariadicContainer struct {
-	list []Variadic
+	list []Item
 }
 
-func NewVariadicContainer(list ...Variadic) *VariadicContainer {
+func NewVariadicContainer(list ...Item) *VariadicContainer {
 	return &VariadicContainer{list: list}
 }
 
 func (vc VariadicContainer) GetInstalled() string {
+	var installed string
+
+	for _, item := range vc.list {
+		installed = fmt.Sprintf("%s,%s", installed, item.String())
+	}
+
+	return installed
+}
+
+type NotVariadicContainer struct {
+	list []Item
+}
+
+func NewNotVariadicContainer(list []Item) *NotVariadicContainer {
+	return &NotVariadicContainer{list: list}
+}
+
+func (vc NotVariadicContainer) GetInstalled() string {
 	var installed string
 
 	for _, item := range vc.list {

--- a/test/variadic_test.go
+++ b/test/variadic_test.go
@@ -18,9 +18,7 @@ func TestVariadicNone(t *testing.T) {
 	graph.Define(
 		&container,
 		inject.NewProvider(
-			func() *variadic.VariadicContainer{
-				return variadic.NewVariadicContainer()
-			},
+			variadic.NewVariadicContainer,
 		),
 	)
 	graph.ResolveAll()
@@ -38,9 +36,8 @@ func TestVariadicOne(t *testing.T) {
 	graph.Define(
 		&container,
 		inject.NewProvider(
-			func() *variadic.VariadicContainer{
-				return variadic.NewVariadicContainer(variadic.NewV1())
-			},
+			variadic.NewVariadicContainer,
+			variadic.NewV1(),
 		),
 	)
 	graph.ResolveAll()
@@ -58,12 +55,70 @@ func TestVariadicAll(t *testing.T) {
 	graph.Define(
 		&container,
 		inject.NewProvider(
-			func() *variadic.VariadicContainer{
-				return variadic.NewVariadicContainer(
-					variadic.NewV1(),
-					variadic.NewV2(),
-					variadic.NewV3(),
-				)
+			variadic.NewVariadicContainer,
+			variadic.NewV1(),
+			variadic.NewV2(),
+			variadic.NewV3(),
+		),
+	)
+	graph.ResolveAll()
+
+	Expect(container.GetInstalled()).To(Equal(",v1,v2,v3"))
+}
+
+func TestNotVariadicNone(t *testing.T) {
+	RegisterTestingT(t)
+
+	graph := inject.NewGraph()
+
+	var container *variadic.NotVariadicContainer
+
+	graph.Define(
+		&container,
+		inject.NewProvider(
+			variadic.NewNotVariadicContainer,
+			&[]variadic.Item{},
+		),
+	)
+	graph.ResolveAll()
+
+	Expect(container.GetInstalled()).To(Equal(""))
+}
+
+func TestNotVariadicOne(t *testing.T) {
+	RegisterTestingT(t)
+
+	graph := inject.NewGraph()
+
+	var container *variadic.NotVariadicContainer
+
+	graph.Define(
+		&container,
+		inject.NewProvider(
+			variadic.NewNotVariadicContainer,
+			&[]variadic.Item{variadic.NewV1()},
+		),
+	)
+	graph.ResolveAll()
+
+	Expect(container.GetInstalled()).To(Equal(",v1"))
+}
+
+func TestNotVariadicAll(t *testing.T) {
+	RegisterTestingT(t)
+
+	graph := inject.NewGraph()
+
+	var container *variadic.NotVariadicContainer
+
+	graph.Define(
+		&container,
+		inject.NewProvider(
+			variadic.NewNotVariadicContainer,
+			&[]variadic.Item{
+				variadic.NewV1(),
+				variadic.NewV2(),
+				variadic.NewV3(),
 			},
 		),
 	)


### PR DESCRIPTION
Fix provider for slice arguments. This bug cause changes for variadic methods.

```
$ go test ./...
?       github.com/karlkfi/inject       [no test files]
ok      github.com/karlkfi/inject/test  0.007s
?       github.com/karlkfi/inject/test/variadic [no test files]
```